### PR TITLE
Add delta update support for boot partition files

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -355,32 +355,136 @@ task upgrade.a {
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
-    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
-    on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
-    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
-    on-resource bcm2710-rpi-3-b-plus.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b-plus.dtb") }
-    on-resource bcm2710-rpi-cm3.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-cm3.dtb") }
-    on-resource bcm2710-rpi-zero-2-w.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-zero-2-w.dtb") }
-    on-resource overlays/dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
-    on-resource overlays/gpio-poweroff.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/gpio-poweroff.dtbo") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
-    on-resource overlays/ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource overlays/rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
-    on-resource overlays/rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo") }
-    on-resource overlays/vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource start.elf {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="start.elf"
+        fat_write(${BOOT_A_PART_OFFSET}, "start.elf")
+    }
+    on-resource fixup.dat {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="fixup.dat"
+        fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_A_PART_OFFSET}, "config.txt")
+    }
+    on-resource kernel8.img {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="kernel8.img"
+        fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img")
+    }
+    on-resource bcm2710-rpi-3-b.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-3-b.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb")
+    }
+    on-resource bcm2710-rpi-3-b-plus.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-3-b-plus.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b-plus.dtb")
+    }
+    on-resource bcm2710-rpi-cm3.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-cm3.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-cm3.dtb")
+    }
+    on-resource bcm2710-rpi-zero-2-w.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-zero-2-w.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-zero-2-w.dtb")
+    }
+    on-resource overlays/dwc2.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/dwc2.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo")
+    }
+    on-resource overlays/gpio-poweroff.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/gpio-poweroff.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/gpio-poweroff.dtbo")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/overlay_map.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/overlay_map.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb")
+    }
+    on-resource overlays/ramoops.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo")
+    }
+    on-resource overlays/rpi-backlight.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-backlight.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo")
+    }
+    on-resource overlays/rpi-ft5406.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-ft5406.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-7inch.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -445,32 +549,136 @@ task upgrade.b {
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_B_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat") }
-    on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
-    on-resource kernel8.img { fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img") }
-    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
-    on-resource bcm2710-rpi-3-b-plus.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b-plus.dtb") }
-    on-resource bcm2710-rpi-cm3.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-cm3.dtb") }
-    on-resource bcm2710-rpi-zero-2-w.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-zero-2-w.dtb") }
-    on-resource overlays/dwc2.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo") }
-    on-resource overlays/gpio-poweroff.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/gpio-poweroff.dtbo") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/overlay_map.dtb { fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb") }
-    on-resource overlays/ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource overlays/rpi-backlight.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
-    on-resource overlays/rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo") }
-    on-resource overlays/vc4-kms-v3d.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource start.elf {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="start.elf"
+        fat_write(${BOOT_B_PART_OFFSET}, "start.elf")
+    }
+    on-resource fixup.dat {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="fixup.dat"
+        fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_B_PART_OFFSET}, "config.txt")
+    }
+    on-resource kernel8.img {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="kernel8.img"
+        fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img")
+    }
+    on-resource bcm2710-rpi-3-b.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-3-b.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b.dtb")
+    }
+    on-resource bcm2710-rpi-3-b-plus.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-3-b-plus.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b-plus.dtb")
+    }
+    on-resource bcm2710-rpi-cm3.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-cm3.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-cm3.dtb")
+    }
+    on-resource bcm2710-rpi-zero-2-w.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2710-rpi-zero-2-w.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-zero-2-w.dtb")
+    }
+    on-resource overlays/dwc2.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/dwc2.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo")
+    }
+    on-resource overlays/gpio-poweroff.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/gpio-poweroff.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/gpio-poweroff.dtbo")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/overlay_map.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/overlay_map.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb")
+    }
+    on-resource overlays/ramoops.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo")
+    }
+    on-resource overlays/rpi-backlight.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-backlight.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo")
+    }
+    on-resource overlays/rpi-ft5406.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-ft5406.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-7inch.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}

--- a/fwup.conf.eex
+++ b/fwup.conf.eex
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -285,7 +285,11 @@ task upgrade.a {
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -350,7 +354,11 @@ task upgrade.b {
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}


### PR DESCRIPTION
cmdline.txt is excluded since the copy on the other boot partition is
the other slot's variant.

Bump require-fwup-version to 1.12.0.